### PR TITLE
Add function to fetch thumbnail from grid drag event.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grid-util-js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "JS helpers for the Grid",
   "main": "src/index.js",
   "license": "Apache-2.0",
@@ -12,7 +12,7 @@
     "url": "https://github.com/guardian/grid-util-js"
   },
   "devDependencies": {
-    "eslint": "^1.6.0",
+    "eslint": "^1.10.3",
     "jspm": "^0.16.11",
     "karma": "^0.13.10",
     "karma-mocha": "^0.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ export default class Grid {
 	static get GRID_URL_DATA_IDENTIFIER() {
 		return 'application/vnd.mediaservice.kahuna.uri';
 	}
+	static get IMAGE_DATA_IDENTIFIER() {
+        return 'application/vnd.mediaservice.image+json';
+    }
 
 	constructor({
 		apiBaseUrl,
@@ -91,6 +94,17 @@ export default class Grid {
 			}
 		}
 	}
+
+    getThumbnailFromEvent(evt) {
+        var imageData = getData(evt, Grid.IMAGE_DATA_IDENTIFIER);
+        if (imageData) {
+            try {
+                return JSON.parse(imageData).data.thumbnail;
+            } catch (ex) {
+                return;
+            }
+        }
+    }
 
 	getGridUrlFromEvent(evt) {
 		return getData(evt, Grid.GRID_URL_DATA_IDENTIFIER);

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,8 @@ export default class Grid {
 		return 'application/vnd.mediaservice.kahuna.uri';
 	}
 	static get IMAGE_DATA_IDENTIFIER() {
-        return 'application/vnd.mediaservice.image+json';
-    }
+		return 'application/vnd.mediaservice.image+json';
+	}
 
 	constructor({
 		apiBaseUrl,
@@ -95,16 +95,16 @@ export default class Grid {
 		}
 	}
 
-    getThumbnailFromEvent(evt) {
-        var imageData = getData(evt, Grid.IMAGE_DATA_IDENTIFIER);
-        if (imageData) {
-            try {
-                return JSON.parse(imageData).data.thumbnail;
-            } catch (ex) {
-                return;
-            }
-        }
-    }
+	getThumbnailFromEvent(evt) {
+		var imageData = getData(evt, Grid.IMAGE_DATA_IDENTIFIER);
+		if (imageData) {
+			try {
+				return JSON.parse(imageData).data.thumbnail;
+			} catch (ex) {
+				return;
+			}
+		}
+	}
 
 	getGridUrlFromEvent(evt) {
 		return getData(evt, Grid.GRID_URL_DATA_IDENTIFIER);


### PR DESCRIPTION
Currently facia tool uses the smallest grid crop as the thumbnail. This is bad as the grid ultimately shouldn't be managing lots of different extra crop sizes other than the ones made by users. This change adds a function to extract the thumbnail block of a drag event from the grid, to end reliance on the generated crops.